### PR TITLE
feat(knight-strike): onboard repo + GitHub Pages custom domain

### DIFF
--- a/dns/main.tf
+++ b/dns/main.tf
@@ -23,6 +23,15 @@ resource "cloudflare_dns_record" "vpn" {
   ttl     = 60
 }
 
+resource "cloudflare_dns_record" "knight-strike" {
+  zone_id = cloudflare_zone.clo5de-info.id
+  name    = "knight-strike"
+  content = "jackey8616.github.io"
+  type    = "CNAME"
+  proxied = true
+  ttl     = 1
+}
+
 
 # silverfish.cc — managed in this module since dns/ already owns Cloudflare
 # zones. Apex points at GitHub Pages (4 IPs); www / blog / morpheus / webmail

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -1,0 +1,9 @@
+# The GitHub module's Pages custom domain follows this record directly, so the
+# Pages setting can't drift from the DNS record. Referencing .name (rather than
+# name + zone) is deliberate: the Cloudflare provider returns it as the full
+# FQDN (knight-strike.clo5de.info) after a refresh, so appending the zone would
+# double it.
+output "knight-strike-pages-fqdn" {
+  description = "FQDN of the knight-strike GitHub Pages CNAME, for the GitHub module's Pages custom domain."
+  value       = cloudflare_dns_record.knight-strike.name
+}

--- a/github/repositories.tf
+++ b/github/repositories.tf
@@ -23,3 +23,25 @@ resource "github_repository" "silverfish-vue" {
   allow_rebase_merge     = true
   allow_squash_merge     = true
 }
+
+resource "github_repository" "knight-strike" {
+  name        = "knight-strike"
+  description = ""
+  visibility  = "public"
+
+  has_issues             = true
+  has_projects           = true
+  delete_branch_on_merge = true
+  allow_merge_commit     = true
+  allow_rebase_merge     = true
+  allow_squash_merge     = true
+}
+
+# GitHub Pages custom domain. The Pages site is built by a workflow; this only
+# sets the custom domain (Settings → Pages → Custom domain). The cname is sourced
+# from the dns/ module's knight-strike CNAME (var) so the two can't drift.
+resource "github_repository_pages" "knight-strike" {
+  repository = github_repository.knight-strike.name
+  build_type = "workflow"
+  cname      = var.knight-strike-pages-cname
+}

--- a/github/variable.tf
+++ b/github/variable.tf
@@ -14,3 +14,8 @@ variable "repository-variables" {
   default     = {}
   description = "Outer key: GitHub repo name. Inner: variable name (will be prefixed with TF_) → value."
 }
+
+variable "knight-strike-pages-cname" {
+  type        = string
+  description = "Custom domain for the knight-strike GitHub Pages site. Sourced from the dns/ module's knight-strike CNAME so the Pages setting and the DNS record can't drift."
+}

--- a/main.tf
+++ b/main.tf
@@ -9,9 +9,10 @@ module "GitHubOIDC" {
 }
 
 module "GitHub" {
-  source          = "./github"
-  github-org-name = local.github-org-name
-  github-token    = var.terraform-management.github-token
+  source                    = "./github"
+  github-org-name           = local.github-org-name
+  github-token              = var.terraform-management.github-token
+  knight-strike-pages-cname = module.DNS.knight-strike-pages-fqdn
   repository-variables = {
     "Silverfish-Backend" = {
       GCP_PROJECT_ID                 = module.Silverfish.silverfish.backend.project_id


### PR DESCRIPTION
## What

Brings the existing **knight-strike** GitHub repo under Terraform and wires its GitHub Pages custom domain end to end.

- **`github/`** — import `knight-strike` as a `github_repository`, standardising its settings to the convention used by the other managed repos (`delete_branch_on_merge`, merge options, etc.).
- **`dns/`** — add `knight-strike.clo5de.info` CNAME → `jackey8616.github.io` in the `clo5de.info` zone (proxied, mirroring `www.silverfish.cc`).
- **Pages custom domain** — set via the non-deprecated `github_repository_pages` resource. Its `cname` **follows the dns/ record directly** (`dns` output = `cloudflare_dns_record.knight-strike.name` → `github` var) so the DNS record and the Pages setting can't drift.

## Why `.name` alone (not `name + zone`)

The Cloudflare v5 provider returns `cloudflare_dns_record.name` as the **full FQDN** (`knight-strike.clo5de.info`) after a refresh, so referencing `.name` alone yields the correct domain; appending the zone would double it (`...clo5de.info.clo5de.info`).

## Applied state

The repo import, DNS record, and Pages cname were already applied during development (targeted applies). `terraform plan` reports **No changes** — this PR is the code catching up to live state, so a post-merge plan should be clean.

## Note (matches the existing silverfish setup)

Because the CNAME is proxied (orange cloud), GitHub can't provision its own cert, so Pages "Enforce HTTPS" stays off; HTTPS to the browser is served by Cloudflare. Flip `proxied = false` if you'd rather GitHub manage the cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)