### PR TITLE
feat(Clode-Tools): add Tokyo VPN alongside Taiwan one

### DIFF
--- a/clode-tools/ip.tf
+++ b/clode-tools/ip.tf
@@ -2,3 +2,8 @@ resource "google_compute_address" "ipsec" {
   name   = "ipsec-ip"
   region = var.region
 }
+
+resource "google_compute_address" "ipsec_jp" {
+  name   = "ipsec-ip-jp"
+  region = var.region-jp
+}

--- a/clode-tools/output.tf
+++ b/clode-tools/output.tf
@@ -4,6 +4,10 @@ output "clode-tools" {
       ip           = google_compute_address.ipsec.address
       check-status = "gcloud compute ssh ipsec-vpn-tw --zone=${var.zone} --project=${var.gcp-project-id} --command='docker ps && docker logs l2tp-ipsec-vpn'"
     }
+    vpn-jp = {
+      ip           = google_compute_address.ipsec_jp.address
+      check-status = "gcloud compute ssh ipsec-vpn-jp --zone=${var.zone-jp} --project=${var.gcp-project-id} --command='docker ps && docker logs l2tp-ipsec-vpn'"
+    }
   }
   sensitive = true
 }

--- a/clode-tools/variable.tf
+++ b/clode-tools/variable.tf
@@ -18,6 +18,16 @@ variable "zone" {
   default = "asia-east1-b"
 }
 
+variable "region-jp" {
+  type    = string
+  default = "asia-northeast1"
+}
+
+variable "zone-jp" {
+  type    = string
+  default = "asia-northeast1-a"
+}
+
 variable "machine_type" {
   type    = string
   default = "e2-micro"

--- a/clode-tools/vm.tf
+++ b/clode-tools/vm.tf
@@ -1,3 +1,34 @@
+locals {
+  # Shared container spec for both VPN instances. Rendering is deterministic, so
+  # extracting it here is a no-op for the existing Taiwan instance's state.
+  ipsec-container-declaration = yamlencode({
+    spec = {
+      containers = [{
+        name  = "l2tp-ipsec-vpn"
+        image = "hwdsl2/ipsec-vpn-server"
+        env = [
+          { name = "VPN_USER", value = var.vpn-username },
+          { name = "VPN_PASSWORD", value = var.vpn-password },
+          { name = "VPN_IPSEC_PSK", value = var.vpn-psk },
+        ]
+        securityContext = {
+          privileged = true
+        }
+        volumeMounts = [{
+          name      = "lib-modules"
+          mountPath = "/lib/modules"
+          readOnly  = true
+        }]
+      }]
+      volumes = [{
+        name     = "lib-modules"
+        hostPath = { path = "/lib/modules" }
+      }]
+      restartPolicy = "Always"
+    }
+  })
+}
+
 resource "google_compute_instance" "ipsec" {
   name         = "ipsec-vpn-tw"
   machine_type = var.machine_type
@@ -20,32 +51,44 @@ resource "google_compute_instance" "ipsec" {
   }
 
   metadata = {
-    gce-container-declaration = yamlencode({
-      spec = {
-        containers = [{
-          name  = "l2tp-ipsec-vpn"
-          image = "hwdsl2/ipsec-vpn-server"
-          env = [
-            { name = "VPN_USER", value = var.vpn-username },
-            { name = "VPN_PASSWORD", value = var.vpn-password },
-            { name = "VPN_IPSEC_PSK", value = var.vpn-psk },
-          ]
-          securityContext = {
-            privileged = true
-          }
-          volumeMounts = [{
-            name      = "lib-modules"
-            mountPath = "/lib/modules"
-            readOnly  = true
-          }]
-        }]
-        volumes = [{
-          name     = "lib-modules"
-          hostPath = { path = "/lib/modules" }
-        }]
-        restartPolicy = "Always"
-      }
-    })
+    gce-container-declaration = local.ipsec-container-declaration
+  }
+
+  scheduling {
+    preemptible         = var.use-spot
+    automatic_restart   = var.use-spot ? false : true
+    on_host_maintenance = var.use-spot ? "TERMINATE" : "MIGRATE"
+    provisioning_model  = var.use-spot ? "SPOT" : "STANDARD"
+  }
+
+  service_account {
+    scopes = ["cloud-platform"]
+  }
+}
+
+resource "google_compute_instance" "ipsec_jp" {
+  name         = "ipsec-vpn-jp"
+  machine_type = var.machine_type
+  zone         = var.zone-jp
+  tags         = ["ipsec-vpn"]
+
+  boot_disk {
+    initialize_params {
+      image = "cos-cloud/cos-stable"
+      size  = 10
+      type  = "pd-standard"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      nat_ip = google_compute_address.ipsec_jp.address
+    }
+  }
+
+  metadata = {
+    gce-container-declaration = local.ipsec-container-declaration
   }
 
   scheduling {

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -23,6 +23,15 @@ resource "cloudflare_dns_record" "vpn" {
   ttl     = 60
 }
 
+resource "cloudflare_dns_record" "vpn-jp" {
+  zone_id = cloudflare_zone.clo5de-info.id
+  name    = "vpn-jp"
+  content = var.vpn-jp-ip
+  type    = "A"
+  proxied = false
+  ttl     = 60
+}
+
 resource "cloudflare_dns_record" "knight-strike" {
   zone_id = cloudflare_zone.clo5de-info.id
   name    = "knight-strike"

--- a/dns/variable.tf
+++ b/dns/variable.tf
@@ -12,6 +12,11 @@ variable "vpn-ip" {
   sensitive = true
 }
 
+variable "vpn-jp-ip" {
+  type      = string
+  sensitive = true
+}
+
 variable "silverfish-backend-hostname" {
   type        = string
   description = "Cloud Run hostname for the Silverfish backend (no protocol)."

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ module "DNS" {
   cf-account-id               = var.terraform-management.cf-account-id
   ip                          = module.ClodeClaw.clode-claw.instance.public_ipv4
   vpn-ip                      = module.Clode-Tools.clode-tools.vpn.ip
+  vpn-jp-ip                   = module.Clode-Tools.clode-tools.vpn-jp.ip
   silverfish-backend-hostname = module.Silverfish.silverfish.backend.api_cname_target
 }
 


### PR DESCRIPTION
## What

Add a second L2TP/IPsec VPN endpoint in **Tokyo (`asia-northeast1`)** next to the existing Taiwan one, both running `hwdsl2/ipsec-vpn-server`.

## How

- Reuses the existing **Clode-Tools GCP project**, `default` network, and the network-level `allow-ipsec` firewall (tag `ipsec-vpn` covers the new instance across regions) — no new project/billing link.
- Reuses the same `vpn-username` / `vpn-password` / `vpn-psk`, so **no `terraform.tfvars.json` change** is required.
- Extracts the shared container spec into a `local` referenced by both instances. Rendering is deterministic, so this is a **no-op for the existing Taiwan instance's state**.
- Publishes the Tokyo static IP as **`vpn-jp.clo5de.info`**; the Taiwan `vpn.clo5de.info` record is untouched.

## Changes

| File | Change |
|---|---|
| `clode-tools/ip.tf` | new static IP `ipsec-ip-jp` (`asia-northeast1`) |
| `clode-tools/vm.tf` | shared container `local` + new instance `ipsec-vpn-jp` (`asia-northeast1-a`) |
| `clode-tools/variable.tf` | `region-jp` / `zone-jp` (default Tokyo) |
| `clode-tools/output.tf` | new `vpn-jp.{ip,check-status}` |
| `dns/{main,variable}.tf` | new `vpn-jp` A record |
| `main.tf` | wire `vpn-jp-ip` into the DNS module |

## Applied

Already applied via `-target=module.Clode-Tools -target='module.DNS.cloudflare_dns_record.vpn-jp'`:

```
Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

- `vpn-jp.clo5de.info` → `136.110.66.54` (Tokyo) ✅ resolves
- `vpn.clo5de.info` → `34.80.187.116` (Taiwan) — unchanged ✅

> Note: applied with `-target` to sidestep a pre-existing, unrelated MongoDB Atlas API-key-access-list 403 that surfaces during full-plan refresh of the Silverfish module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)