### PR TITLE
feat(pyfun): ACM-issued DNS-validated cert, drop imported private key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ Single-module work: you can also `cd <module>/ && terraform ...` only for `valid
 - `.aws_credentials` — AWS shared-credentials file. Referenced by *both* the AWS provider (`provider.tf`) and the S3 backend (`version.tf`). Default profile is used.
 - Sensitive variables are **not** stored locally — they live in AWS Secrets Manager (one secret per module; see the "Secrets" section below). There is no `terraform.tfvars.json` anymore. `.aws_credentials` remains gitignored — never commit it.
 - `~/.ssh/github.pub` — read by `credentials.tf` and injected as the MacBook Air SSH key into Linode.
-- `pyfun/certs/pyfun-backend-v2.clo5de.info.{key,pem}` — TLS cert/key for the PyFun API Gateway custom domain; the paths come from the `pyfun` secret's `aws-cert-key-path` / `aws-cert-pem-path`. (Still a local secret — the cert/key content is not yet migrated into Secrets Manager.)
+
+(`.aws_credentials` and `~/.ssh/github.pub` are the only local files now — there is no local cert or tfvars anymore.)
 
 ## Secrets (AWS Secrets Manager)
 
@@ -41,6 +42,13 @@ There are 13 secrets: the former `terraform-management` catch-all is split by pr
 - Edit one value: `scripts/secrets-edit.sh <name>` (fetch → `$EDITOR` → push a new version).
 - Bulk-seed from a `terraform.tfvars.json` (first-time migration or disaster recovery): `scripts/secrets-push.sh`.
 - Caveat: read values are copied into the S3 state. The state's encryption + access control is the real security boundary — not the absence of a local file.
+
+### PyFun TLS certificate
+
+PyFun's API Gateway custom domain (`pyfun-backend-v2.clo5de.info`) uses an **ACM-issued, DNS-validated** certificate defined at root in `pyfun-cert.tf`. It spans two providers — `aws` for issuance (must be in the API Gateway's region, `ap-northeast-1`) and `cloudflare` for the validation record in the `clo5de.info` zone — so it lives at root and its validated ARN is injected into `module.PyFun`. ACM auto-renews it; no private key is stored in Terraform or on disk.
+
+- The previous **imported** cert (arn `eabee32f`, valid to 2039) is no longer managed by Terraform (`state rm`'d, left alive in ACM). Both it and the new cert are `InUseBy` production load balancers in a **separate AWS account** (`969236854626`, `prod-nrt-1-cdtls-*`) — some external TLS-terminating platform auto-attaches ACM certs for this domain. Consequence: the cert auto-renews in place fine, but **cannot be destroyed/replaced while in use** (`terraform destroy` of it fails with `ResourceInUseException` — this is what broke the first migration apply).
+- The imported cert's private key + body are cold-backed-up in the `private-cloud/pyfun-legacy-cert` secret (**not** read by Terraform; kept only because ACM cannot export an imported cert's key).
 
 ## Architecture: how the modules fit together
 

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -7,3 +7,8 @@ output "knight-strike-pages-fqdn" {
   description = "FQDN of the knight-strike GitHub Pages CNAME, for the GitHub module's Pages custom domain."
   value       = cloudflare_dns_record.knight-strike.name
 }
+
+output "clo5de-info-zone-id" {
+  description = "Zone ID of the clo5de.info Cloudflare zone, for records managed outside this module (e.g. the root-level ACM DNS-validation record for PyFun)."
+  value       = cloudflare_zone.clo5de-info.id
+}

--- a/main.tf
+++ b/main.tf
@@ -49,8 +49,7 @@ module "PyFun" {
   GitHub-OIDC-Arn                    = aws_iam_openid_connect_provider.GitHub.arn
   Lambda-EdgeFunctionExecuteRole-Arn = aws_iam_policy.AWSLambdaEdgeExecutionRole.arn
   ECR-Image-Sha                      = local.pyfun["aws-ecr-image-sha"]
-  Cert_Key_Path                      = local.pyfun["aws-cert-key-path"]
-  Cert_Pem_Path                      = local.pyfun["aws-cert-pem-path"]
+  Cert_Arn                           = aws_acm_certificate_validation.pyfun_backend_v2.certificate_arn
 }
 
 module "Seeker" {

--- a/pyfun-cert.tf
+++ b/pyfun-cert.tf
@@ -1,0 +1,40 @@
+# ACM-issued, DNS-validated TLS cert for the PyFun API Gateway regional custom
+# domain (pyfun-backend-v2.clo5de.info). It lives at root, not in the pyfun module,
+# because it spans two providers: the certificate (aws — must be in the API
+# Gateway's region, ap-northeast-1) and its DNS validation record (cloudflare — in
+# the clo5de.info zone owned by module.DNS). The validated ARN is injected into
+# module.PyFun, so the pyfun module stays AWS-only and no private key is ever stored
+# — ACM generates and auto-renews it; nothing lands in Secrets Manager or on disk.
+resource "aws_acm_certificate" "pyfun_backend_v2" {
+  domain_name       = "pyfun-backend-v2.clo5de.info"
+  validation_method = "DNS"
+
+  tags = aws_servicecatalogappregistry_application.terraform.application_tag
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "cloudflare_dns_record" "pyfun_backend_v2_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.pyfun_backend_v2.domain_validation_options :
+    dvo.domain_name => {
+      name    = trimsuffix(dvo.resource_record_name, ".")
+      type    = dvo.resource_record_type
+      content = trimsuffix(dvo.resource_record_value, ".")
+    }
+  }
+
+  zone_id = module.DNS.clo5de-info-zone-id
+  name    = each.value.name
+  content = each.value.content
+  type    = each.value.type
+  proxied = false
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "pyfun_backend_v2" {
+  certificate_arn         = aws_acm_certificate.pyfun_backend_v2.arn
+  validation_record_fqdns = [for record in cloudflare_dns_record.pyfun_backend_v2_cert_validation : record.name]
+}

--- a/pyfun/README.md
+++ b/pyfun/README.md
@@ -4,10 +4,6 @@
 .
 ├── README.md
 ├── api_gateway.tf
-├── cerfiticate.tf
-├── certs
-│   ├── pyfun-backend-v2.clo5de.info.key
-│   └── pyfun-backend-v2.clo5de.info.pem
 ├── lambda.tf
 ├── main.tf
 ├── permissions.tf

--- a/pyfun/api_gateway.tf
+++ b/pyfun/api_gateway.tf
@@ -181,7 +181,7 @@ resource "aws_api_gateway_stage" "v2_stage" {
 
 resource "aws_api_gateway_domain_name" "pyfun-backend-v2_clo5de_info" {
   domain_name              = "pyfun-backend-v2.clo5de.info"
-  regional_certificate_arn = aws_acm_certificate.pyfun-backend-v2_clo5de_info.arn
+  regional_certificate_arn = var.Cert_Arn
 
   tags = merge(aws_servicecatalogappregistry_application.pyfun.application_tag)
 

--- a/pyfun/cerfiticate.tf
+++ b/pyfun/cerfiticate.tf
@@ -1,8 +1,0 @@
-resource "aws_acm_certificate" "pyfun-backend-v2_clo5de_info" {
-  private_key      = file(var.Cert_Key_Path)
-  certificate_body = file(var.Cert_Pem_Path)
-
-  tags = merge(aws_servicecatalogappregistry_application.pyfun.application_tag)
-
-  tags_all = merge(aws_servicecatalogappregistry_application.pyfun.application_tag)
-}

--- a/pyfun/variable.tf
+++ b/pyfun/variable.tf
@@ -10,10 +10,6 @@ variable "ECR-Image-Sha" {
   type = string
 }
 
-variable "Cert_Key_Path" {
-  type = string
-}
-
-variable "Cert_Pem_Path" {
+variable "Cert_Arn" {
   type = string
 }


### PR DESCRIPTION
## What

Replace PyFun's **imported** ACM certificate (its private key lived on disk at `pyfun/certs/*.key` and briefly in the `pyfun` secret) with an **ACM-issued, DNS-validated** cert that ACM **auto-renews**. No private key on disk or in a Terraform-read secret anymore.

## Changes

- **`pyfun-cert.tf`** (new, root) — `aws_acm_certificate` (DNS validation) + `cloudflare_dns_record` validation record + `aws_acm_certificate_validation`. Lives at root because it spans the `aws` (issuance in `ap-northeast-1`) and `cloudflare` (validation record in `clo5de.info`) providers; the validated ARN is injected into `module.PyFun`, which stays AWS-only.
- **`dns/outputs.tf`** — expose `clo5de-info-zone-id` for the root validation record.
- **pyfun module** — `Cert_Key_Path` / `Cert_Pem_Path` → `Cert_Arn`; delete the imported `aws_acm_certificate` (`cerfiticate.tf`).
- **CLAUDE.md / pyfun README** — document the ACM approach; drop the local-cert references.

## Applied & verified

- New cert `AMAZON_ISSUED` / `ISSUED` / renewal `ELIGIBLE`; API Gateway domain now serves it (`AVAILABLE`).
- Local `pyfun/certs/*` deleted after byte-exact backup to the `private-cloud/pyfun-legacy-cert` secret.

## Gotcha (documented)

The retired imported cert (arn `eabee32f`, valid to 2039) is left alive and unmanaged (`state rm`'d) — it and the new cert are `InUseBy` prod ELBs in a **separate account** (`969236854626`, `prod-nrt-1-cdtls-*`), so ACM refuses to delete it (this is what stalled the first apply). It auto-renews in place but cannot be destroyed/replaced while in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)