### PR TITLE
feat(aws): resolve credentials via default chain (SSO), not a local key file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,12 @@ terraform output -json clode-claw           # sensitive outputs — must pass th
 
 Single-module work: you can also `cd <module>/ && terraform ...` only for `validate`/`fmt`. Real `plan`/`apply` must run from root because state, backend, and cross-module wiring live there.
 
-## Required local files (gitignored, must exist before `init`/`plan`)
+## Local prerequisites & AWS auth
 
-- `.aws_credentials` — AWS shared-credentials file. Referenced by *both* the AWS provider (`provider.tf`) and the S3 backend (`version.tf`). Default profile is used.
-- Sensitive variables are **not** stored locally — they live in AWS Secrets Manager (one secret per module; see the "Secrets" section below). There is no `terraform.tfvars.json` anymore. `.aws_credentials` remains gitignored — never commit it.
-- `~/.ssh/github.pub` — read by `credentials.tf` and injected as the MacBook Air SSH key into Linode.
-
-(`.aws_credentials` and `~/.ssh/github.pub` are the only local files now — there is no local cert or tfvars anymore.)
+- **AWS auth uses the default credential chain** — `provider.tf` and the `version.tf` backend no longer pin a credentials file or profile. Authenticate on any machine with **IAM Identity Center (SSO)**: `aws sso login`, then `export AWS_PROFILE=<your-sso-profile>` (profile names are per-machine, e.g. `pc-sso-rowan-air`) and `terraform init -reconfigure`. The S3 backend, both `aws` providers, and the Secrets Manager reads all resolve from that. A static `.aws_credentials` file still works if you point `AWS_SHARED_CREDENTIALS_FILE`/`AWS_PROFILE` at it, but is no longer required — and stays gitignored, never commit it.
+- **GCP auth** is `gcloud auth application-default login` (interactive). AWS SSO + gcloud ADC = deploy from any machine with no secret file carried.
+- Sensitive variables are **not** stored locally — they live in AWS Secrets Manager (one secret per module; see the "Secrets" section below). There is no `terraform.tfvars.json` anymore.
+- `~/.ssh/github.pub` — read by `credentials.tf` and injected as the MacBook Air SSH key into Linode (a public key, not a secret).
 
 ## Secrets (AWS Secrets Manager)
 

--- a/provider.tf
+++ b/provider.tf
@@ -4,15 +4,12 @@ provider "cloudflare" {
 }
 
 provider "aws" {
-  region                   = "ap-northeast-1"
-  shared_credentials_files = [".aws_credentials"]
-  profile                  = "default"
+  region = "ap-northeast-1"
 }
 
 provider "aws" {
-  region                   = "ap-southeast-2"
-  alias                    = "sydney"
-  shared_credentials_files = [".aws_credentials"]
+  region = "ap-southeast-2"
+  alias  = "sydney"
 }
 
 provider "linode" {

--- a/version.tf
+++ b/version.tf
@@ -22,12 +22,10 @@ terraform {
   }
 
   backend "s3" {
-    encrypt                 = true
-    bucket                  = "terraform-state20240420133633131400000001"
-    key                     = "build-instance/terraform.tfstate"
-    region                  = "ap-northeast-1"
-    dynamodb_table          = "terraform_lock"
-    shared_credentials_file = ".aws_credentials"
-    profile                 = "default"
+    encrypt        = true
+    bucket         = "terraform-state20240420133633131400000001"
+    key            = "build-instance/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "terraform_lock"
   }
 }


### PR DESCRIPTION
## What

Remove the hardcoded `shared_credentials_files` / `shared_credentials_file` / `profile` from both `aws` providers (`provider.tf`) and the S3 backend (`version.tf`). AWS auth now resolves via the **default credential chain** (`AWS_PROFILE` / SSO cache / env / OIDC), so no static `.aws_credentials` file needs to be carried between machines.

## Deploy flow now

```bash
aws sso login --profile <your-sso-profile>   # IAM Identity Center
export AWS_PROFILE=<your-sso-profile>
terraform init -reconfigure                   # backend changed
terraform plan
```
Paired with `gcloud auth application-default login`, deploys run from any machine with **zero secret files carried**.

## Verified

Against an IAM Identity Center SSO profile (AdministratorAccess): `terraform init -reconfigure` re-inits the S3 backend over SSO, and `terraform plan -target=module.ClodeClaw` (exercises the aws provider, Secrets Manager reads, and the cloudflare/linode providers seeded from them) → **No changes**.

## Follow-up (manual, not in this PR)

Once fully switched: deactivate + delete the `terraform` IAM user's static access key, and delete the local `.aws_credentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)